### PR TITLE
Use SYSTRAN Pure Neural Server instead of systran.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 When working with the Sitefinity CMS *Translation* module, you can benefit from a number of translation connectors that you use out-of-the-box with minimum setup. You can, however, implement your own translation connector with custom logic to serve your requirements. 
 
-This tutorial provides you with a sample that you use to implement a custom translation connector to work with the **Systran.io** service. You first create and setup the connector and then use the *Systran Translation .Net Client Library*  to implement the overall translation process.   
+This tutorial provides you with a sample that you use to implement a custom translation connector to work with the **SYSTRAN Pure Neural Server** service. You first create and setup the connector and then use the *Systran Translation .Net Client Library*  to implement the overall translation process.   
 ## Requirements
 Sitefinity CMS license
 
@@ -12,7 +12,7 @@ Sitefinity CMS license
 
 Your Sitefinity CMS web site must be in multilingual mode meaning that you have added atleast one additinal language to the current website you are browsing. Otherwise you will not see the translations screen in the administrations tab of your application.
 
-Currently, **Systran.io** machine translation service does not support specific languages like 'en-US', you can use neutral culture like 'en', or specify a mapping between the specific culture and neutral culture in the translations advanced settings screen: <i>Administration >> Settings >> Advanced >> Culture mappings </i> text box.
+Currently, **SYSTRAN Pure Neural Server** machine translation service supports two-letter ISO language codes like 'en' 'fr' 'de' 'es' 'nl' etc., you can use neutral culture like 'en', or specify a mapping between the specific culture and neutral culture in the translations advanced settings screen: <i>Administration >> Settings >> Advanced >> Culture mappings </i> text box.
 
 Add the *Systran Machine Translation* sample project to your solution. To do this:
 
@@ -21,7 +21,7 @@ Add the *Systran Machine Translation* sample project to your solution. To do thi
 3. In **SystranMachineTranslation** add a reference to the **SystranClientTranslationApiLib** assembly. Download from Systran Natural Language Processing .Net Client Library from https://github.com/SYSTRAN/translation-api-csharp-client.
 4. Ensure Telerik.Sitefinity.Translations nuget package is installed in **SystranMachineTranslation**.
 5. In **SitefinityWebApp**, add a reference to the **SystranMachineTranslation** project.
-6. In **SitefinityWebApp** add apiKey.txt file containing key obtained from Systran.io https://platform.systran.net/user/admin#/apiKeys .
+6. In **SitefinityWebApp** add apiKey.txt file containing key obtained from Systran http://www.systransoft.com/contact/.
 7. Compile your solution
 
 ## Create and configure the connector
@@ -35,4 +35,4 @@ To configure the *SystranMachineTranslationConnector* connector in Sitefinity CM
 5. To enable the connector, in the <i>Enabled</i> field, enter <strong>true</strong>.
 6. Save your changes.
 
-Note: Systran.io is not supporting culture-specific languages.
+Note: SYSTRAN Pure Neural Server is not supporting culture-specific languages.


### PR DESCRIPTION
The SYSTRAN Pure Neural Server end point has been tested by the team several months ago and it works with the current implementation. Also, the code has been reviewed by Systran and they recommended NOT to promote Systran.io, since it has been deprecated.